### PR TITLE
fix: member.has_any_role working on member

### DIFF
--- a/interactions/models/discord/user.py
+++ b/interactions/models/discord/user.py
@@ -592,6 +592,15 @@ class Member(DiscordObject, _SendDMMixin):
         """
         return all(to_snowflake(role) in self._role_ids for role in roles)
 
+    def has_any_role(self, roles: List[Union[Snowflake_Type, Role]]) -> bool:
+        """
+        Checks if the user has any of the given roles.
+
+        Args:
+            *roles: The Role(s) or role id(s) to check for
+        """
+        return any((self.has_role(to_snowflake(role)) for role in roles))
+
     async def timeout(
         self,
         communication_disabled_until: Union["Timestamp", datetime, int, float, str, None],


### PR DESCRIPTION
## Pull Request Type
- [x] Feature addition
- [x] Bugfix
- [ ] Documentation update
- [ ] Code refactor
- [ ] Tests improvement
- [ ] CI/CD pipeline enhancement
- [ ] Other: [Replace with a description]

## Description
This PR fixes has_any_role() not working on member object by adding it to user.py and makes it work as originally [documented](https://interactions-py.github.io/interactions.py/API%20Reference/API%20Reference/models/Internal/checks/#interactions.models.internal.checks.has_any_role).

## Changes
- Add has_any_role() to user.py

## Test Scenarios
Use has_any_role() on member object.


## Python Compatibility
- [x] I've ensured my code works on Python `3.10.x`
- [x] I've ensured my code works on Python `3.11.x`


## Checklist
- [x] I've run the `pre-commit` code linter over all edited files
- [x] I've tested my changes on supported Python versions
- [x] I've added tests for my code, if applicable
- [x] I've updated / added  documentation, where applicable
